### PR TITLE
Add visibility of start and end dates for work streams

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+require 'date'
+require 'dotenv/load'
 require 'sinatra'
 require 'zeitwerk'
-require 'dotenv/load'
 
 loader = Zeitwerk::Loader.new
 loader.push_dir("#{__dir__}/lib/")

--- a/lib/use_case/view_teams.rb
+++ b/lib/use_case/view_teams.rb
@@ -17,6 +17,8 @@ class UseCase::ViewTeams
       data[row[0]][:project] << {
         project_name: row[1],
         person: row[2],
+        start_date: row[3],
+        end_date: row[4],
         tech_lead: row[9],
         delivery_lead: row[10],
         client_partner: row[11],

--- a/spec/acceptance/schedulinator_spec.rb
+++ b/spec/acceptance/schedulinator_spec.rb
@@ -10,7 +10,6 @@ describe 'the schedule' do
   let(:google_spreadsheet_gateway) { Gateway::GoogleSpreadsheet.new }
   let(:view_teams) { UseCase::ViewTeams.new(google_spreadsheet_gateway: google_spreadsheet_gateway) }
 
-
   it 'views the first client' do
     VCR.use_cassette('account_structure') do
       response = view_teams.execute
@@ -42,20 +41,20 @@ describe 'the schedule' do
   it 'views the account structure of the first person in the first workstream' do
     VCR.use_cassette('account_structure') do
       response = view_teams.execute
-      expect(response.first[:project].first[:tech_lead]).to eq('TRUE')
-      expect(response.first[:project].first[:delivery_lead]).to eq('TRUE')
-      expect(response.first[:project].first[:client_partner]).to eq('TRUE')
-      expect(response.first[:project].first[:exec_sponsor]).to eq('TRUE')
+      expect(response.first[:project].first[:tech_lead]).to eq('FALSE')
+      expect(response.first[:project].first[:delivery_lead]).to eq('FALSE')
+      expect(response.first[:project].first[:client_partner]).to eq('FALSE')
+      expect(response.first[:project].first[:exec_sponsor]).to eq('FALSE')
     end
   end
 
   it 'views the account structure of the second person in the first workstream' do
     VCR.use_cassette('account_structure') do
       response = view_teams.execute
-      expect(response.first[:project][1][:tech_lead]).to eq('TRUE')
+      expect(response.first[:project][1][:tech_lead]).to eq('FALSE')
       expect(response.first[:project][1][:delivery_lead]).to eq('FALSE')
       expect(response.first[:project][1][:client_partner]).to eq('FALSE')
-      expect(response.first[:project][1][:exec_sponsor]).to eq('TRUE')
+      expect(response.first[:project][1][:exec_sponsor]).to eq('FALSE')
     end
   end
 end

--- a/spec/unit/use_case/view_teams_spec.rb
+++ b/spec/unit/use_case/view_teams_spec.rb
@@ -10,29 +10,66 @@ describe 'view deliverys' do
   let(:google_spreadsheet_gateway) { Gateway::GoogleSpreadsheet.new }
   let(:view_teams) { UseCase::ViewTeams.new(google_spreadsheet_gateway: google_spreadsheet_gateway) }
 
-  it 'views the first team' do
+  it 'can show client as the first key for the data' do
     VCR.use_cassette('response') do
       response = view_teams.execute
-      expect(response.first[:client]).to eq('Bob Corp')
+      expect(response.first.keys[0]).to eq(:client)
     end
   end
 
-  it 'views the first team' do
+  it 'can show project name as the first key on the first active work stream' do
     VCR.use_cassette('response') do
       response = view_teams.execute
-      expect(response.first).to eq(
-        client: 'Bob Corp',
-        project: [
-          {
-            person: 'George',
-            project_name: 'Project 1'
-          },
-          {
-            person: 'Yusuf',
-            project_name: 'Project 1'
-          }
-        ]
-      )
+      expect(response.first[:project][0].keys[0]).to eq(:project_name)
+    end
+  end
+
+  it 'can show person as the second key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[1]).to eq(:person)
+    end
+  end
+
+  it 'can show start date as the third key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[2]).to eq(:start_date)
+    end
+  end
+
+  it 'can show end date as the fourth key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[3]).to eq(:end_date)
+    end
+  end
+
+  it 'can show tech lead as the fifth key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[4]).to eq(:tech_lead)
+    end
+  end
+
+  it 'can show delivery lead as the sixth key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[5]).to eq(:delivery_lead)
+    end
+  end
+
+  it 'can show client partner as the seventh key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[6]).to eq(:client_partner)
+    end
+  end
+
+  it 'can show exec sponsor as the eigth key on the first active work stream' do
+    VCR.use_cassette('response') do
+      response = view_teams.execute
+      expect(response.first[:project][0].keys[7]).to eq(:exec_sponsor)
     end
   end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -77,7 +77,12 @@
                   | <span class="badge badge-pill badge-info">Executive Sponsor</span>
                 <% end %>
               </h5>
-                <%= x[:project_name] %>
+              <%= x[:project_name] %>
+              <div class="float-right">
+                <% start_on, end_on = Date.strptime(x[:start_date], '%Y-%m-%d'), Date.strptime(x[:end_date], '%Y-%m-%d') %> 
+                <%= start_on.day %> <%= Date::MONTHNAMES[start_on.month] %> <%= start_on.year %> to 
+                <%= end_on.day %> <%= Date::MONTHNAMES[end_on.month] %> <%= end_on.year %>
+              </div>
             <% end %>
           </a>
         </div>


### PR DESCRIPTION
## What

- Implement visibility of start and end dates for active work streams
- Change the way tests work

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/47318342/60717877-0e0a4c00-9f1b-11e9-9ce9-b996425a73ef.png">

## Why

- We need to be able to see the dates for each work stream so we are aware of the duration/length of each project
- Tests are now checking for keys rather than the values to ensure use case outputs correct format rather than testing the data presented from the spreadsheet itself