### PR TITLE
Show when projects will be ending

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -70,8 +70,14 @@
                       <% start_on, end_on = Date.strptime(dates[:start_date], '%Y-%m-%d'), Date.strptime(dates[:end_date], '%Y-%m-%d') %>
                       <%= start_on.day %> <%= Date::MONTHNAMES[start_on.month] %> <%= start_on.year %> to
                       <%= end_on.day %> <%= Date::MONTHNAMES[end_on.month] %> <%= end_on.year %>
-                      <% if end_on - 30 < Date.today %>
-                        <p>Project ends in the next 30 days</p>
+                      <% if end_on < Date.today %>
+                        <div class="alert alert-danger text-center">
+                          Project has ended
+                        </div>
+                      <% elsif Date.today > end_on - 30 && end_on + 30 > Date.today%>
+                        <div class="alert alert-warning text-center">
+                          Project is ending
+                        </div>
                       <% end %>
                     </div>
                     <% break %>


### PR DESCRIPTION
<img width="888" alt="Screenshot 2019-07-09 at 12 24 23" src="https://user-images.githubusercontent.com/40758489/60884323-88e9a480-a244-11e9-8dad-91b85f9424fc.png">

WHAT: Include visual alerts when a project will end or is going to end soon
WHY: To give visibility when a project is coming to the end of its contract