### PR TITLE
Add progress bars for each work stream

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -94,12 +94,24 @@
                           <%= start_on.day %> <%= Date::MONTHNAMES[start_on.month] %> <%= start_on.year %> to
                           <%= end_on.day %> <%= Date::MONTHNAMES[end_on.month] %> <%= end_on.year %>
                           <% if end_on < Date.today %>
-                            <div class="alert alert-danger text-center">
-                              Project has ended
+                            <div class="progress">
+                              <div class="progress-bar bg-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
                             </div>
                           <% elsif Date.today > end_on - 30 && end_on + 30 > Date.today%>
-                            <div class="alert alert-warning text-center">
-                              Project is ending
+                            <div class="progress">
+                              <div class="progress-bar bg-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                          <% elsif Date.today > start_on && start_on + 30 < Date.today %>
+                            <div class="progress">
+                              <div class="progress-bar bg-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                          <% elsif start_on > Date.today %>
+                            <div class="progress">
+                              <div class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                          <% else %>
+                            <div class="progress">
+                              <div class="progress-bar bg-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
                             </div>
                           <% end %>
                         <% end %>

--- a/views/present.erb
+++ b/views/present.erb
@@ -60,7 +60,7 @@
             <div class="d-flex w-100 justify-content-between">
               <a class="list-group-item list-group-item-action mb-3">
                 <h5 class="mb-1 mt-0">
-                  Account Structure
+                  Account Structure 
                   <br />
                 </h5>
                 <% clients[:project].each do |x| %>
@@ -94,12 +94,24 @@
                           <%= start_on.day %> <%= Date::MONTHNAMES[start_on.month] %> <%= start_on.year %> to
                           <%= end_on.day %> <%= Date::MONTHNAMES[end_on.month] %> <%= end_on.year %>
                           <% if end_on < Date.today %>
-                            <div class="alert alert-danger text-center">
-                              Project has ended
+                            <div class="progress">
+                              <div class="progress-bar bg-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
                             </div>
                           <% elsif Date.today > end_on - 30 && end_on + 30 > Date.today%>
-                            <div class="alert alert-warning text-center">
-                              Project is ending
+                            <div class="progress">
+                              <div class="progress-bar bg-warning" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                          <% elsif Date.today > start_on && start_on + 30 < Date.today %>
+                            <div class="progress">
+                              <div class="progress-bar bg-info" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                          <% elsif start_on > Date.today %>
+                            <div class="progress">
+                              <div class="progress-bar" role="progressbar" style="width: 0%" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+                            </div>
+                          <% else %>
+                            <div class="progress">
+                              <div class="progress-bar bg-success" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div>
                             </div>
                           <% end %>
                         <% end %>


### PR DESCRIPTION
## What

- Remove alerts for when project has ended or ending soon
- Add progress bars for each work stream

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/47318342/60983092-43ef6c00-a331-11e9-9b41-2af7996b489d.png">

## Why

- We can visualise when projects have started recently, ongoing, ending soon and has already ended