### PR TITLE
Remove labels for members on work streams

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -118,12 +118,6 @@
                     <% person[:person].each do |name| %>
                       <%= name %>
                     <% end %>
-                    <% if person[:delivery_lead] == 'TRUE'%>
-                      <span class="badge badge-success">Delivery Lead</span>
-                    <% end %>
-                    <% if person[:tech_lead] == 'TRUE' %>
-                      <span class="badge badge-secondary">Technical Lead</span>
-                    <% end %>
                     <br />
                   <% end %>
                   <br />

--- a/views/present.erb
+++ b/views/present.erb
@@ -118,12 +118,6 @@
                     <% person[:person].each do |name| %>
                       <%= name %>
                     <% end %>
-                    <% if person[:delivery_lead] == 'TRUE'%>
-                      <span class="badge badge-success">Delivery Lead</span>
-                    <% end %>
-                    <% if person[:tech_lead] == 'TRUE' %>
-                      <span class="badge badge-secondary">Technical Lead</span>
-                    <% end %>
                     <br />
                   <% end %>
                   <br />


### PR DESCRIPTION
## What

- Remove labels for work streams

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/47318342/61119867-a1033300-a493-11e9-8f75-262bac63d301.png">

## Why

- Iterate on user feedback and improve visibility