### PR TITLE
Rename structure to team

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -60,7 +60,7 @@
             <div class="d-flex w-100 justify-content-between">
               <a class="list-group-item list-group-item-action mb-3">
                 <h5 class="mb-1 mt-0">
-                  Account Structure
+                  Account Team
                   <br />
                 </h5>
                 <% clients[:project].each do |x| %>

--- a/views/present.erb
+++ b/views/present.erb
@@ -61,7 +61,7 @@
             <div class="d-flex w-100 justify-content-between">
               <a class="list-group-item list-group-item-action mb-3">
                 <h5 class="mb-1 mt-0">
-                  Account Structure
+                  Account Team
                   <br />
                 </h5>
                 <% clients[:project].each do |x| %>


### PR DESCRIPTION
## What

- Rename `structure` to `team`

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/47318342/61121708-c85bff00-a497-11e9-9c0a-6f13574f7a8f.png">

## Why

- Improves readability